### PR TITLE
Use HTTPS Git URL instead of SSH for Opaque spdlog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include(FetchContent)
 set(FETCHCONTENT_QUIET OFF)
 FetchContent_Declare(
     spdlog
-    GIT_REPOSITORY git@github.com:opaque-systems/spdlog.git
+    GIT_REPOSITORY https://github.com/opaque-systems/spdlog.git
 )
 FetchContent_MakeAvailable(spdlog)
 


### PR DESCRIPTION
Use HTTPS URL so that we don't have to authenticate using an SSH key to clone an open source repo