### PR TITLE
Use HTTPS instead of SSH for fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To build `mc2-utils` for an enclave, add the following to your `CMakeLists.txt` 
 include(FetchContent)
 FetchContent_Declare(
   mc2_utils_e
-  GIT_REPOSITORY git@github.com:mc2-systems/mc2-utils.git
+  GIT_REPOSITORY https//github.com/mc2-systems/mc2-utils.git
 )
 set(FETCHCONTENT_QUIET OFF)
 


### PR DESCRIPTION
Discussed with Chester: since everything is open source now, we should use HTTPS to avoid adding secrets in the Actions workflow.