### PR TITLE
Add logging format

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -9,6 +9,12 @@ Crypto::Crypto(): m_initialized(false)
 {
     int res = -1;
 
+#ifdef HOST
+    spdlog::set_pattern("%Y-%m-%d %H:%M:%S - HOST - %l - %v");
+#else
+    spdlog::set_pattern("%Y-%m-%d %H:%M:%S - ENCLAVE - %l - %v");
+#endif
+
     mbedtls_ctr_drbg_init(&m_ctr_drbg_context);
     mbedtls_entropy_init(&m_entropy_context);
     mbedtls_pk_init(&m_pk_context);


### PR DESCRIPTION
This PR modifies `mc2-utils` to use a better spdlog log format which tells the user whether they are in a HOST or ENCLAVE environment