### PR TITLE
Fix concurrency bugs

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -352,7 +352,10 @@ int Crypto::SymEnc(
         spdlog::error("Failed to perform symmetric key encryption.");
         spdlog::error("Returned error: {}", to_string(res));
     }
-
+    
+    // Free the GCM context
+    mbedtls_gcm_free(&ctx);
+    
     return res;
 }
 
@@ -407,6 +410,10 @@ int Crypto::SymDec(
         spdlog::error("Failed to perform symmetric key decryption.");
         spdlog::error("Returned error: {}", to_string(res));
     }
+    
+    // Free the GCM context
+    mbedtls_gcm_free(&ctx);
+
     return res;
 }
 
@@ -437,7 +444,7 @@ int Crypto::Hash(
     safe_sha(mbedtls_sha256_update_ret(&ctx, data, data_size));
     safe_sha(mbedtls_sha256_finish_ret(&ctx, output));
 
-    // Clear the hash context
+    // Free the hash context
     mbedtls_sha256_free(&ctx);
 
     return res;

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -55,12 +55,6 @@ Crypto::Crypto(): m_initialized(false)
         return;
     }
 
-    // Initialize GCM context
-    mbedtls_gcm_init(&m_gcm_context);
-
-    // Initialize SHA256 context
-    mbedtls_sha256_init(&m_hash_ctx);
-
     m_initialized = true;
     spdlog::info("Successfully initialized cryptography module.");
 }
@@ -69,7 +63,6 @@ Crypto::Crypto(): m_initialized(false)
 Crypto::~Crypto()
 {
     // Free mbedtls contexts
-    mbedtls_gcm_free(&m_gcm_context);
     mbedtls_pk_free(&m_pk_context);
     mbedtls_entropy_free(&m_entropy_context);
     mbedtls_ctr_drbg_free(&m_ctr_drbg_context);
@@ -309,8 +302,9 @@ int Crypto::SymEnc(
 ) {
     int res = -1;
 
-    if (!m_initialized)
-        return res;
+    // Initialize GCM context
+    mbedtls_gcm_context ctx;
+    mbedtls_gcm_init(&ctx);
     
     // Set the pointers so that the ciphertext is formatted as:
     //     IV || TAG || ENCRYPTED DATA
@@ -320,11 +314,12 @@ int Crypto::SymEnc(
 
     // Add `sym_key` and AES cipher to the current GCM context
     res = mbedtls_gcm_setkey(
-        &m_gcm_context,
+        &ctx,
         MBEDTLS_CIPHER_ID_AES,
         sym_key,
         CIPHER_KEY_SIZE * 8); // Key size is given in bits
     if( res != 0 ) {
+        mbedtls_gcm_free(&ctx);
         spdlog::error("Failed to set symmetric key during symmetric key encryption.");
         spdlog::error("Returned error: {}", to_string(res));
         return res;
@@ -333,6 +328,7 @@ int Crypto::SymEnc(
     // Sample randomness for the IV
     res = RandGen(iv, CIPHER_IV_SIZE);
     if( res != 0 ) {
+        mbedtls_gcm_free(&ctx);
         spdlog::error("Failed to generate IV during symmetric key encryption.");
         spdlog::error("Returned error: {}", to_string(res));
         return res;
@@ -340,10 +336,10 @@ int Crypto::SymEnc(
 
     // Encrypt data
     res = mbedtls_gcm_crypt_and_tag( 
-        &m_gcm_context,
+        &ctx,
         MBEDTLS_GCM_ENCRYPT,
         data_size,
-        iv, // TODO: Might need to cast here
+        iv,
         CIPHER_IV_SIZE,
         aad,
         aad_size,
@@ -352,9 +348,11 @@ int Crypto::SymEnc(
         CIPHER_TAG_SIZE,
         tag);
     if( res != 0 ) {
+        mbedtls_gcm_free(&ctx);
         spdlog::error("Failed to perform symmetric key encryption.");
         spdlog::error("Returned error: {}", to_string(res));
     }
+
     return res;
 }
 
@@ -369,16 +367,18 @@ int Crypto::SymDec(
 ) {
     int res = -1;
 
-    if (!m_initialized)
-        return res;
+    // Initialize GCM context
+    mbedtls_gcm_context ctx;
+    mbedtls_gcm_init(&ctx);
 
     // Add `sym_key` and AES cipher to the current GCM context
     res = mbedtls_gcm_setkey(
-        &m_gcm_context,
+        &ctx,
         MBEDTLS_CIPHER_ID_AES,
         sym_key,
         CIPHER_KEY_SIZE * 8); // Key size is given in bits
     if( res != 0 ) {
+        mbedtls_gcm_free(&ctx);
         spdlog::error("Failed to set symmetric key during symmetric key decryption.");
         spdlog::error("Returned error: {}", to_string(res));
         return res;
@@ -392,7 +392,7 @@ int Crypto::SymDec(
 
     // Decrypt the data
     res = mbedtls_gcm_auth_decrypt(
-        &m_gcm_context,
+        &ctx,
         enc_data_size - CIPHER_IV_SIZE - CIPHER_TAG_SIZE,
         iv,
         CIPHER_IV_SIZE,
@@ -403,6 +403,7 @@ int Crypto::SymDec(
         ciphertext,
         data);
     if (res != 0) {
+        mbedtls_gcm_free(&ctx);
         spdlog::error("Failed to perform symmetric key decryption.");
         spdlog::error("Returned error: {}", to_string(res));
     }
@@ -417,28 +418,27 @@ int Crypto::Hash(
 ) {
     int res = -1;
 
-    if (!m_initialized)
-        return res;
+    // Initialize SHA256 context
+    mbedtls_sha256_context ctx;
+    mbedtls_sha256_init(&ctx);
 
 // Macro to simplify error handling
-#define safe_sha(call) {                  \
-  res = (call);                           \
-  if (res) {                              \
-    mbedtls_sha256_free(&m_hash_ctx);     \
-    spdlog::error("Failed to hash");      \
-    spdlog::error("Returned error: {}",   \
-        to_string(res));                  \
-    return res;                           \
-  }                                       \
+#define safe_sha(call) {                                 \
+  res = (call);                                          \
+  if (res) {                                             \
+    mbedtls_sha256_free(&ctx);                           \
+    spdlog::error("Failed to hash");                     \
+    spdlog::error("Returned error: {}", to_string(res)); \
+    return res;                                          \
+  }                                                      \
 }
-
     // Compute the hash
-    safe_sha(mbedtls_sha256_starts_ret(&m_hash_ctx, 0));
-    safe_sha(mbedtls_sha256_update_ret(&m_hash_ctx, data, data_size));
-    safe_sha(mbedtls_sha256_finish_ret(&m_hash_ctx, output));
+    safe_sha(mbedtls_sha256_starts_ret(&ctx, 0));
+    safe_sha(mbedtls_sha256_update_ret(&ctx, data, data_size));
+    safe_sha(mbedtls_sha256_finish_ret(&ctx, output));
 
     // Clear the hash context
-    mbedtls_sha256_free(&m_hash_ctx);
+    mbedtls_sha256_free(&ctx);
 
     return res;
 }

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -29,8 +29,6 @@ class Crypto
     mbedtls_ctr_drbg_context m_ctr_drbg_context;
     mbedtls_entropy_context  m_entropy_context;
     mbedtls_pk_context       m_pk_context;
-    mbedtls_gcm_context      m_gcm_context;
-    mbedtls_sha256_context   m_hash_ctx;
     bool                     m_initialized;
     size_t                   rsa_modulus_size;
 


### PR DESCRIPTION
This PR fixes a few concurrency bugs. 

While mbedtls has some threading support (described [here](https://tls.mbed.org/kb/development/thread-safety-and-multi-threading) and enabled by OpenEnclave [here](https://github.com/openenclave/openenclave/blob/master/3rdparty/mbedtls/config.h#L2904)), the GCM and SHA256 contexts are not thread-safe. Neither of these contexts need to be global, so they've each been removed as member variables and added to the respective member functions.