### PR TITLE
Upgrade to Open Enclave 0.17.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install apt package dependencies
         run: |
-          # Install OpenEnclave 0.12.0
+          # Install OpenEnclave 0.17.1
           echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
           wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-bionic-7.list
@@ -31,7 +31,7 @@ jobs:
           wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 
           sudo apt update
-          sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.12.0 
+          sudo apt -y install clang-8 libssl-dev gdb libsgx-enclave-common libsgx-quote-ex libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.17.1
 
           # CMake
           wget https://github.com/Kitware/CMake/releases/download/v3.15.6/cmake-3.15.6-Linux-x86_64.sh
@@ -74,7 +74,7 @@ jobs:
 
       - name: Install apt package dependencies
         run: |
-          # Install OpenEnclave 0.12.0
+          # Install OpenEnclave 0.17.1
           echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
           wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-bionic-7.list
@@ -83,7 +83,7 @@ jobs:
           wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 
           sudo apt update
-          sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.12.0 
+          sudo apt -y install clang-8 libssl-dev gdb libsgx-enclave-common libsgx-quote-ex libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.17.1
 
           # CMake
           wget https://github.com/Kitware/CMake/releases/download/v3.15.6/cmake-3.15.6-Linux-x86_64.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,12 @@ FetchContent_MakeAvailable(spdlog)
 add_compile_definitions(SPDLOG_NO_THREAD_ID FMT_USE_INT128=0)
 include_directories(${spdlog_SOURCE_DIR}/include)
 
-find_package(OpenEnclave CONFIG REQUIRED)
+set(OE_MIN_VERSION 0.17.1)
+find_package(OpenEnclave ${OE_MIN_VERSION} CONFIG REQUIRED)
+
+set(OE_CRYPTO_LIB
+    mbedtls
+    CACHE STRING "Crypto library used by enclaves.")
 
 set(OPAQUE_UTILS_SOURCES
     src/crypto.cpp
@@ -62,12 +67,12 @@ else()
       target_link_libraries(
         mc2_utils_e
         PRIVATE
-        openenclave::oeenclave-lvi-cfg openenclave::oelibcxx-lvi-cfg openenclave::oecore)
+        openenclave::oeenclave-lvi-cfg openenclave::oecrypto${OE_CRYPTO_LIB}-lvi-cfg openenclave::oelibcxx-lvi-cfg openenclave::oecore)
     else()
       target_link_libraries(
         mc2_utils_e
         PRIVATE
-        openenclave::oeenclave openenclave::oelibcxx openenclave::oecore)
+        openenclave::oeenclave openenclave::oecrypto${OE_CRYPTO_LIB} openenclave::oelibcxx openenclave::oecore)
     endif()
 
     set_target_properties(mc2_utils_e PROPERTIES

--- a/src/attestation.cpp
+++ b/src/attestation.cpp
@@ -94,12 +94,14 @@ int Attestation::GenerateEvidence(const oe_uuid_t* format_id,
     }
 
     // Generate evidence
-    oe_res = oe_get_evidence(format_id, 0, claims_buf, claims_buf_size,
-                             format_settings, format_settings_size, evidence,
-                             evidence_size, nullptr, 0);
+    // Reference for this function here:
+    // https://github.com/openenclave/openenclave/blob/cd72fd7069488ba6f453c8f5f47bd9fd9a6e6c0d/include/openenclave/attestation/attester.h#L75
+    oe_res = oe_get_evidence(format_id, 0, claims_buf, claims_buf_size, nullptr,
+                             0, evidence, evidence_size, nullptr, 0);
+
     if (oe_res != OE_OK) {
         spdlog::error("Failed to generate attestation evidence.");
-        spdlog::error("Returned error: {}", to_string(res));
+        spdlog::error("Returned error: {}", to_string(oe_res));
         return -1;
     }
     return res;


### PR DESCRIPTION
Updates to use Open Enclave 0.17.1

* From July 31, Open Enclave 0.12.0 attestation [no longer works on Azure](https://lists.confidentialcomputing.io/g/oesdk/topic/open_enclave_sdk_update/84256170?p=,,,20,0,0,0::recentpostdate%2Fsticky,,,20,2,0,84256170)
* Explicitly links against `oecrypto` library. Since [Open Enclave 0.13](https://github.com/openenclave/openenclave/releases/tag/v0.13.0), the `oeenclave` library no longer automatically includes the OE crypto wrapper library.
* Removes format settings from being passed into `oe_get_evidence()` - the API for `oe_get_evidence()` has been changed (but is not well-documented!). Instead of format settings, [optional parameters](https://github.com/openenclave/openenclave/blob/cd72fd7069488ba6f453c8f5f47bd9fd9a6e6c0d/docs/DesignDocs/NotesOnAttestationAPI.md#semantics-of-custom-claims-and-optional-parameters) are passed. We do not need to pass any optional parameters for now.